### PR TITLE
Pin scanspec to 1.0a1 and fix tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ requires-python = ">=3.11"
 [project.optional-dependencies]
 dev = [
     "blueapi>=1.2.1",
+    "scanspec<=1.0a2",
     "copier",
     "pipdeptree",
     "pre-commit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 
 [tool.coverage.run]
+patch = ["subprocess"]
 data_file = "/tmp/test_rig_bluesky.coverage"
 
 [tool.coverage.paths]

--- a/tests/system_tests/conftest.py
+++ b/tests/system_tests/conftest.py
@@ -52,7 +52,7 @@ def instrument() -> str:
 @pytest.fixture
 def latest_commissioning_instrument_session() -> str:
     # Hardcoding this until a suitable API comes along
-    return "cm40661-1"
+    return "cm40661-6"
 
 
 @pytest.fixture

--- a/tests/unit_tests/test_plans.py
+++ b/tests/unit_tests/test_plans.py
@@ -64,6 +64,11 @@ async def test_spectroscopy(RE: RunEngine):
     mock_detector_behavior(_spectroscopy_detector)
 
     _sample_stage = sample_stage(connect_immediately=True, mock=True)
+    set_mock_value(_sample_stage.x.low_limit_travel, -10.0)
+    set_mock_value(_sample_stage.x.high_limit_travel, 10.0)
+    set_mock_value(_sample_stage.y.low_limit_travel, -10.0)
+    set_mock_value(_sample_stage.y.high_limit_travel, 10.0)
+
     set_mock_value(_sample_stage.x.velocity, 1.0)
     set_mock_value(_sample_stage.y.velocity, 1.0)
 
@@ -103,6 +108,11 @@ async def test_spectroscopy_defaults(RE: RunEngine):
     mock_detector_behavior(_spectroscopy_detector)
 
     _sample_stage = sample_stage(connect_immediately=True, mock=True)
+    set_mock_value(_sample_stage.x.low_limit_travel, -10.0)
+    set_mock_value(_sample_stage.x.high_limit_travel, 10.0)
+    set_mock_value(_sample_stage.y.low_limit_travel, -10.0)
+    set_mock_value(_sample_stage.y.high_limit_travel, 10.0)
+
     set_mock_value(_sample_stage.x.velocity, 1.0)
     set_mock_value(_sample_stage.y.velocity, 1.0)
 


### PR DESCRIPTION
Due to a breaking change between scanspec 1.0a1 and 1.0a2, they need to be upgraded together. I have pinned scanspec here, once it is upgraded server-side the system tests will fail until the pin is removed.