### PR TITLE
Update spectroscopy detector whitelist

### DIFF
--- a/src/test_rig_bluesky/plans.py
+++ b/src/test_rig_bluesky/plans.py
@@ -86,6 +86,9 @@ def spectroscopy(
         design_name="spectroscopy_detector_baseline",
         whitelist_pvs=[
             "fileio-nd_array_port",
+            "fileio-enable_callbacks",
+            "driver-trigger_mode",
+            "driver-trigger_source",
             "roistat-channels-array_counter",
             "roistat-channels-1-min_x",
             "roistat-channels-1-min_y",
@@ -105,6 +108,7 @@ def spectroscopy(
             "roistat-channels-3-size_x",
             "roistat-channels-3-size_y",
             "roistat-channels-3-use",
+            "roistat-enable_callbacks",
         ],
     )
 

--- a/src/test_rig_bluesky/plans.py
+++ b/src/test_rig_bluesky/plans.py
@@ -87,6 +87,7 @@ def spectroscopy(
         whitelist_pvs=[
             "fileio-nd_array_port",
             "fileio-enable_callbacks",
+            "driver-acquire",
             "driver-trigger_mode",
             "driver-trigger_source",
             "roistat-channels-array_counter",
@@ -108,6 +109,7 @@ def spectroscopy(
             "roistat-channels-3-size_x",
             "roistat-channels-3-size_y",
             "roistat-channels-3-use",
+            "roistat-nd_array_port",
             "roistat-enable_callbacks",
         ],
     )


### PR DESCRIPTION
Adds more PVs to the `spectroscopy_detector` whitelist for loading during the spectroscopy plan to ensure detector is in good state. 