### PR TITLE
exclude pyright version 1.1.407

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
     "copier",
     "pipdeptree",
     "pre-commit",
-    "pyright==1.1.406",
+    "pyright!=1.1.407",
     "pytest",
     "pytest-asyncio",
     "pytest-cov",


### PR DESCRIPTION
A new version of pyright is out (1.1.408), and the [bug](https://github.com/microsoft/pyright/issues/11060) in version 1.1.407 has been addressed.
This excludes the buggy version, allowing the new version to be used.